### PR TITLE
Add client UI with ticket status colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Ticket Checker
+
+Simple page for verifying ticket codes via the `/check` endpoint. The page colors the
+background according to the ticket status:
+
+- **Green** (`.ok`) for valid tickets.
+- **Gold** (`.vip`) for valid VIP tickets.
+- **Red** (`.used`) for invalid or already used tickets.
+
+After each check the input field stays focused and is cleared so scanning can
+continue quickly.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ background according to the ticket status:
 - **Red** (`.used`) for invalid or already used tickets.
 
 After each check the input field stays focused and is cleared so scanning can
-continue quickly.
+continue quickly. The page also shows a brief message describing the ticket
+status, such as "Entrada válida", "VIP", or when a code is not found or was
+already used.

--- a/public/index.html
+++ b/public/index.html
@@ -9,10 +9,12 @@
     body.used { background: #ffa8a8; }
     body.vip { background: gold; }
     input { font-size: 1.2em; padding: 0.5em; }
+    #status { margin-top: 1em; font-size: 1.5em; font-weight: bold; }
   </style>
 </head>
 <body>
   <input id="ticket" placeholder="Enter ticket code" autofocus>
+  <p id="status"></p>
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ticket Checker</title>
+  <style>
+    body.ok { background: #b2f2bb; }
+    body.used { background: #ffa8a8; }
+    body.vip { background: gold; }
+    input { font-size: 1.2em; padding: 0.5em; }
+  </style>
+</head>
+<body>
+  <input id="ticket" placeholder="Enter ticket code" autofocus>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,30 @@
+const input = document.getElementById('ticket');
+
+async function checkTicket(code) {
+  try {
+    const res = await fetch(`/check?code=${encodeURIComponent(code)}`);
+    const data = await res.json();
+    document.body.classList.remove('ok', 'used', 'vip');
+    if (data.valid) {
+      if (data.type === 'VIP') {
+        document.body.classList.add('vip');
+      } else {
+        document.body.classList.add('ok');
+      }
+    } else {
+      document.body.classList.add('used');
+    }
+  } catch (e) {
+    document.body.classList.remove('ok', 'vip');
+    document.body.classList.add('used');
+  } finally {
+    input.value = '';
+    input.focus();
+  }
+}
+
+input.addEventListener('keydown', (ev) => {
+  if (ev.key === 'Enter' && input.value.trim()) {
+    checkTicket(input.value.trim());
+  }
+});

--- a/public/script.js
+++ b/public/script.js
@@ -1,22 +1,36 @@
 const input = document.getElementById('ticket');
+const status = document.getElementById('status');
 
 async function checkTicket(code) {
   try {
     const res = await fetch(`/check?code=${encodeURIComponent(code)}`);
     const data = await res.json();
     document.body.classList.remove('ok', 'used', 'vip');
+    status.textContent = '';
     if (data.valid) {
       if (data.type === 'VIP') {
         document.body.classList.add('vip');
+        status.textContent = 'Entrada VIP';
       } else {
         document.body.classList.add('ok');
+        status.textContent = 'Entrada válida';
       }
     } else {
       document.body.classList.add('used');
+      if (data.reason === 'not_found') {
+        status.textContent = 'Código no encontrado';
+      } else if (data.reason === 'already_used') {
+        status.textContent = 'Código ya utilizado';
+      } else if (data.message) {
+        status.textContent = data.message;
+      } else {
+        status.textContent = 'Código inválido o ya utilizado';
+      }
     }
   } catch (e) {
     document.body.classList.remove('ok', 'vip');
     document.body.classList.add('used');
+    status.textContent = 'Error al verificar';
   } finally {
     input.value = '';
     input.focus();


### PR DESCRIPTION
## Summary
- create simple Ticket Checker UI
- show green, red or gold backgrounds for status
- keep input clear and focused after checks
- document the status color behavior in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b5491a7bc83318ab2f0d4550b243a